### PR TITLE
Fix template inclusion for overwritten templates

### DIFF
--- a/just-post-preview.widget.php
+++ b/just-post-preview.widget.php
@@ -81,6 +81,7 @@ class JPP_Widget_Post_Preview extends WP_Widget {
 			if ( is_file($template) ) {
 				include ($template);
 				$template_loaded = true;
+				break;
 			}
 		}
 


### PR DESCRIPTION
Hey. First of all: nice plugin! :)
When overwriting one of your layout files inside a custom template, each widget gets displayed twice because inside that loop all found templates are included. The break only uses the first (custom) one.
Cheers.